### PR TITLE
Use solarized dark colorscheme for Neovim

### DIFF
--- a/modules/neovim.nix
+++ b/modules/neovim.nix
@@ -23,9 +23,11 @@
         set cmdheight=2
         set updatetime=300
         set shortmess+=c
-        colorscheme peachpuff
-        set background=light
+        colorscheme NeoSolarized
+        set background=dark
         set number
+        set noshowmode
+        set termguicolors
 
         " Suggested configuration for coc.nvim
         inoremap <silent><expr> <TAB>
@@ -80,7 +82,7 @@
         command! -nargs=0 OR   :call     CocAction('runCommand', 'editor.action.organizeImport')
 
         let g:lightline = {
-          \ 'colorscheme': 'breezy',
+          \ 'colorscheme': 'solarized',
           \ 'component': {
           \   'readonly': '%{&readonly?"":""}',
           \ },
@@ -114,9 +116,19 @@
             sha256 = "09w4glff27sw4z2998gpq5vmlv36mfx9vp287spm7xvaq9fnn6gb";
           };
         };
+        neosolarized = pkgs.vimUtils.buildVimPluginFrom2Nix {
+          pname = "neosolarized";
+          version = "2020-08-06";
+          src = pkgs.fetchFromGitHub {
+            owner = "overcache";
+            repo = "NeoSolarized";
+            rev = "b94b1a9ad51e2de015266f10fdc6e142f97bd617";
+            sha256 = "019nz56yirpg1ahg8adfafrxznalw056qwm3xjm9kzg6da8j6v48";
+          };
+        };
       in with pkgs.vimPlugins; [
         lightline-vim coc-nvim vim-nix fzf-vim coc-fzf fzfWrapper breezy
-        coc-java coc-json coc-python coc-rls coc-yaml
+        coc-java coc-json coc-python coc-rls coc-yaml neosolarized
       ];
     };
     fzf = {


### PR DESCRIPTION
Finally figured out why my colorschemes looked terrible, I hadn't used
`set termguicolors`.